### PR TITLE
Adds splash screen handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,13 +52,14 @@ dependencies {
     implementation "io.github.raamcosta.compose-destinations:core:$compose_destinations"
     ksp "io.github.raamcosta.compose-destinations:ksp:$compose_destinations"
 
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
+    implementation "androidx.compose.ui:ui:$compose_ui_version"
+    implementation "androidx.core:core-splashscreen:1.0.0"
+    implementation 'androidx.activity:activity-compose:1.7.0'
+    implementation 'androidx.compose.material:material:1.4.0'
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.6.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.0'
-    implementation "androidx.compose.ui:ui:$compose_ui_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
-    implementation 'androidx.compose.material:material:1.4.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     ksp "io.github.raamcosta.compose-destinations:ksp:$compose_destinations"
 
     implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.6.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
     implementation 'androidx.activity:activity-compose:1.7.0'
     implementation "androidx.compose.ui:ui:$compose_ui_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.NavigationTests"
+        android:theme="@style/Theme.NavigationTests.SplashScreen"
         tools:targetApi="33">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,16 +6,16 @@
         android:name=".App"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.NavigationTests"
-        tools:targetApi="31">
+        tools:targetApi="33">
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.NavigationTests">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/navigationtests/LoginScreen.kt
+++ b/app/src/main/java/com/example/navigationtests/LoginScreen.kt
@@ -34,7 +34,7 @@ fun LoginScreen(
 ) {
     BackHandler {
         // No op: user can't leave this screen without logging in
-        // We could maybe let him put app on background or similar
+        // We could maybe let them put app on background or similar
     }
 
     val currentState = viewModel.uiState.collectAsState().value
@@ -54,7 +54,7 @@ fun LoginScreenContent(
     popBackStack: () -> Unit,
     currentState: LoginViewModel.UiState
 ) {
-    LaunchedEffect (currentState.done) {
+    LaunchedEffect(currentState.done) {
         if (currentState.done) {
             popBackStack()
         }

--- a/app/src/main/java/com/example/navigationtests/MainActivity.kt
+++ b/app/src/main/java/com/example/navigationtests/MainActivity.kt
@@ -9,10 +9,13 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NamedNavArgument
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -58,9 +61,9 @@ object AuthenticatedScreenWrapper: DestinationWrapper {
     @Composable
     override fun <T> DestinationScope<T>.Wrap(screenContent: @Composable () -> Unit) {
         val diContainer = LocalDiContainer.current
-        val userRepo = remember { diContainer.userRepository }
-
-        when (val userState = userRepo.loggedInUser.collectAsState().value) {
+        val userRepo = remember(diContainer) { diContainer.userRepository }
+        val userState by userRepo.loggedInUser.collectAsStateWithLifecycle()
+        when (userState) {
             is UserRepository.UserState.Loading -> Box(Modifier.fillMaxSize()) {
                 Text(
                     modifier = Modifier.align(Alignment.Center),

--- a/app/src/main/java/com/example/navigationtests/MainActivity.kt
+++ b/app/src/main/java/com/example/navigationtests/MainActivity.kt
@@ -10,12 +10,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NamedNavArgument
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -24,15 +28,32 @@ import com.example.navigationtests.ui.theme.NavigationTestsTheme
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.ramcosta.composedestinations.scope.DestinationScope
 import com.ramcosta.composedestinations.wrapper.DestinationWrapper
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+        val diContainer = (applicationContext as App).diContainer
+        val userRepository = diContainer.userRepository
+        var userState by mutableStateOf(userRepository.loggedInUser.value)
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                val determinedUserState = userRepository
+                    .loggedInUser
+                    .first { it !is UserRepository.UserState.Loading }
+                userState = determinedUserState
+            }
+        }
+        // Keep the splash screen on-screen until the auth status is determined.
+        splashScreen.setKeepOnScreenCondition {
+            userState == UserRepository.UserState.Loading
+        }
         setContent {
             NavigationTestsTheme {
-
                 CompositionLocalProvider(
-                    LocalDiContainer provides (applicationContext as App).diContainer
+                    LocalDiContainer provides diContainer
                 ) {
                     MainComposable()
                 }
@@ -56,7 +77,7 @@ fun MainComposable() {
 }
 
 
-object AuthenticatedScreenWrapper: DestinationWrapper {
+object AuthenticatedScreenWrapper : DestinationWrapper {
 
     @Composable
     override fun <T> DestinationScope<T>.Wrap(screenContent: @Composable () -> Unit) {
@@ -70,7 +91,6 @@ object AuthenticatedScreenWrapper: DestinationWrapper {
                     text = "Loading auth state..."
                 )
             }
-
             is UserRepository.UserState.LoggedOut -> {
                 LaunchedEffect(userState) {
                     destinationsNavigator.navigate(LoginScreenDestination)

--- a/app/src/main/java/com/example/navigationtests/UserRepository.kt
+++ b/app/src/main/java/com/example/navigationtests/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.example.navigationtests
 
 import android.content.SharedPreferences
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -9,7 +10,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-
 
 /**
  * This is NOT how would do it in a real app! Just in case that wasn't clear :D
@@ -28,7 +28,8 @@ class UserRepository(
 
     init {
         coroutineScope.launch {
-            delay(500) // simulating something that takes a bit longer
+            // Splash screen will stay on while the auth status is determined
+            delay(2.seconds) // simulating something that takes a bit longer
             val loggedInUser = sharedPreferences.getString(LOGGED_IN_USERNAME_KEY, null)
                 ?.let { username ->
                     knownUsers.find { it.username == username }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="Theme.NavigationTests.SplashScreen" parent="Theme.SplashScreen">
+        <item name="postSplashScreenTheme">@style/Theme.NavigationTests</item>
+    </style>
+    
     <style name="Theme.NavigationTests" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:statusBarColor">@color/purple_700</item>
     </style>


### PR DESCRIPTION
This should theoretically mean that there will be no case where any other screen would need to handle the UserState.Loading state. As long as there is no case where a UserState ever goes back into Loading, which it really shouldn't.
So having each screen render something special for this case would not be needed, it could be removed completely.